### PR TITLE
Performance improvements in edgelist generation

### DIFF
--- a/EmbDI/edgelist.py
+++ b/EmbDI/edgelist.py
@@ -212,15 +212,14 @@ class EdgeList:
 
         intersection = s1.intersection(s2)
 
-        return list(intersection)
+        return set(intersection)
 
     @staticmethod
     def evaluate_frequencies(flatten, df, intersection):
         if flatten and intersection:
-            intersection_lookup = set(intersection)
             split_values = []
             for val in df.values.ravel().tolist():
-                if val not in intersection_lookup and isinstance(val, str):
+                if val not in intersection and isinstance(val, str):
                     split = val.split("_")
                 else:
                     split = [str(val)]
@@ -287,10 +286,9 @@ class EdgeList:
             except ValueError:
                 pass
 
+        intersection = set()
         if info_file:
             intersection = self.find_intersection_flatten(df, info_file)
-        else:
-            intersection = []
 
         frequencies = self.evaluate_frequencies(flatten, df, intersection)
 

--- a/EmbDI/edgelist.py
+++ b/EmbDI/edgelist.py
@@ -212,7 +212,7 @@ class EdgeList:
 
         intersection = s1.intersection(s2)
 
-        return set(intersection)
+        return intersection
 
     @staticmethod
     def evaluate_frequencies(flatten, df, intersection):

--- a/EmbDI/edgelist.py
+++ b/EmbDI/edgelist.py
@@ -1,7 +1,7 @@
 """This script takes as input a (prepared) csv file, then produces as output
-    a new text file that contains the list of all the edges in the graph. The 
+    a new text file that contains the list of all the edges in the graph. The
     script can also export the edgelist in networkx format, so that the graph
-    can be imported by other programs that use networkx. 
+    can be imported by other programs that use networkx.
 
     Author: Riccardo Cappuzzo
 """
@@ -219,11 +219,8 @@ class EdgeList:
         if flatten and intersection:
             split_values = []
             for val in df.values.ravel().tolist():
-                if val not in intersection:
-                    try:
-                        split = val.split("_")
-                    except AttributeError:
-                        split = [str(val)]
+                if val not in intersection and isinstance(val, str):
+                    split = val.split("_")
                 else:
                     split = [str(val)]
                 split_values += split
@@ -231,9 +228,9 @@ class EdgeList:
         elif flatten:
             split_values = []
             for val in df.values.ravel().tolist():
-                try:
+                if isinstance(val, str):
                     split = val.split("_")
-                except AttributeError:
+                else:
                     split = [str(val)]
                 split_values += split
             frequencies = dict(Counter(split_values))

--- a/EmbDI/edgelist.py
+++ b/EmbDI/edgelist.py
@@ -217,9 +217,10 @@ class EdgeList:
     @staticmethod
     def evaluate_frequencies(flatten, df, intersection):
         if flatten and intersection:
+            intersection_lookup = set(intersection)
             split_values = []
             for val in df.values.ravel().tolist():
-                if val not in intersection and isinstance(val, str):
+                if val not in intersection_lookup and isinstance(val, str):
                     split = val.split("_")
                 else:
                     split = [str(val)]


### PR DESCRIPTION
Hello There,

We currently use EmbDI in Schema-matching and encountered performance issues when matching large datasets with big intersections (~30k rows * ~150 columns * 2 and ~60k intersections).
During edgelist generation, it needs to be checked whether df values are in the intersection. Currently, the intersection is stored as a list, leading to a somewhat quadratic runtime (~9 million iterations over the whole 60k list).

Changing the intersection to a set and avoiding exception generation by using a type check dramatically reduces the time spent in that step (> 6 hours ->  < 2 minutes).

Greetings from Potsdam 